### PR TITLE
[MODEUSCNT-58] Update `openapi-generator` to `v7.12.0`

### DIFF
--- a/mod-erm-usage-counter51/pom.xml
+++ b/mod-erm-usage-counter51/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>mod-erm-usage-counter51</artifactId>
 
   <properties>
-    <openapi-generator.version>7.8.0</openapi-generator.version>
+    <openapi-generator.version>7.12.0</openapi-generator.version>
     <jakarta.annotation.version>3.0.0</jakarta.annotation.version>
     <jakarta.validation.version>3.1.1</jakarta.validation.version>
     <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
@@ -172,34 +172,6 @@
               <modelNameMappings>
                 <!-- clashes with java.lang.Exception in generated code -->
                 <modelNameMapping>Exception=CounterException</modelNameMapping>
-                <!--
-                OpenAPI 'const' keyword is not taken into account during code generation, so
-                there is no way for Jackson to be able to distinguish between these classes.
-                I did not find a way to turn off the creation of inner class
-                'BaseReportHeaderExceptionsInner'.
-                 -->
-                <modelNameMapping>Exception_0=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_1-999=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_1000=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_1010=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_1011=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_1020=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_1030=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_2000=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_2010=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_2011=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_2020=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_3020=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_3030=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_3031=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_3032=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_3040=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_3050=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_3060=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_3061=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_3062=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_3063=CounterException</modelNameMapping>
-                <modelNameMapping>Exception_3070=CounterException</modelNameMapping>
               </modelNameMappings>
             </configuration>
           </execution>
@@ -222,26 +194,6 @@
                   dir="${client.directory}/model"
                   includes="*.java"
                   failOnNoReplacements="true"/>
-              </target>
-            </configuration>
-          </execution>
-          <execution>
-            <id>fix-missing-classes-in-generated-code</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <replaceregexp
-                  match="import ${client.package}.model.*Exception.*;\s*"
-                  replace=""
-                  flags="g">
-                  <fileset
-                    dir="${client.directory}/api"
-                    includes="**/*.java">
-                  </fileset>
-                </replaceregexp>
               </target>
             </configuration>
           </execution>

--- a/mod-erm-usage-counter51/src/main/java/org/olf/erm/usage/counter51/ReportValidator.java
+++ b/mod-erm-usage-counter51/src/main/java/org/olf/erm/usage/counter51/ReportValidator.java
@@ -5,9 +5,7 @@ import static org.olf.erm.usage.counter51.JsonProperties.REPORT_ATTRIBUTES;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_HEADER;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_ID;
 import static org.olf.erm.usage.counter51.ReportValidator.ErrorMessages.ERR_NO_REPORT_ID;
-import static org.olf.erm.usage.counter51.ReportValidator.ErrorMessages.ERR_RELEASE_TEMPLATE;
 import static org.olf.erm.usage.counter51.ReportValidator.ErrorMessages.ERR_REPORT_ATTRIBUTES_TEMPLATE;
-import static org.olf.erm.usage.counter51.ReportValidator.ErrorMessages.ERR_REPORT_ID_TEMPLATE;
 import static org.olf.erm.usage.counter51.ReportValidator.ErrorMessages.ERR_UNSUPPORTED_REPORT_ID_TEMPLATE;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -16,8 +14,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class ReportValidator {
-
-  static final String RELEASE = "5.1";
   private static final String REPORT_CLASS_NAME_TEMPLATE =
       "org.openapitools.counter51client.model.%s";
   private final ObjectMapper objectMapper;
@@ -27,22 +23,18 @@ class ReportValidator {
   }
 
   public ValidationResult validateReport(JsonNode report, ReportType reportType) {
-    return validateByDefintions(report, reportType);
+    return validate(report, reportType);
   }
 
   public ValidationResult validateReport(JsonNode report) {
-    return validateByDefintions(report, null);
+    return validate(report, null);
   }
 
   private String getReportId(JsonNode report) {
     return report.path(REPORT_HEADER).path(REPORT_ID).asText();
   }
 
-  private String getReportRelease(JsonNode report) {
-    return report.path(REPORT_HEADER).path(JsonProperties.RELEASE).asText();
-  }
-
-  private ValidationResult validateByDefintions(JsonNode report, ReportType reportType) {
+  private ValidationResult validate(JsonNode report, ReportType reportType) {
     String reportId = getReportId(report);
 
     if ("".equals(reportId)) {
@@ -61,14 +53,6 @@ class ReportValidator {
     if (!classValidationResult.isValid()) {
       return classValidationResult;
     }
-    ValidationResult reportIdValidationResult = validateReportId(reportId, reportType);
-    if (!reportIdValidationResult.isValid()) {
-      return reportIdValidationResult;
-    }
-    ValidationResult reportReleaseValidationResult = validateReportRelease(report);
-    if (!reportReleaseValidationResult.isValid()) {
-      return reportReleaseValidationResult;
-    }
     return validateReportHeaderReportAttributes(report, reportType);
   }
 
@@ -77,21 +61,6 @@ class ReportValidator {
       objectMapper.convertValue(report, getReportClass(reportType));
     } catch (Exception e) {
       return ValidationResult.error(e);
-    }
-    return ValidationResult.success();
-  }
-
-  private ValidationResult validateReportId(String reportId, ReportType reportType) {
-    String expectedReportID = reportType.toString();
-    if (!expectedReportID.equals(reportId)) {
-      return ValidationResult.error(ERR_REPORT_ID_TEMPLATE, expectedReportID);
-    }
-    return ValidationResult.success();
-  }
-
-  private ValidationResult validateReportRelease(JsonNode report) {
-    if (!RELEASE.equals(getReportRelease(report))) {
-      return ValidationResult.error(ERR_RELEASE_TEMPLATE, RELEASE);
     }
     return ValidationResult.success();
   }
@@ -160,9 +129,7 @@ class ReportValidator {
   static class ErrorMessages {
 
     static final String ERR_NO_REPORT_ID = "Could not find 'reportId'";
-    static final String ERR_RELEASE_TEMPLATE = "Expected 'release' to be: '%s'";
     static final String ERR_REPORT_ATTRIBUTES_TEMPLATE = "Expected 'reportAttributes' to be: %s";
-    static final String ERR_REPORT_ID_TEMPLATE = "Expected 'reportId' to be: %s";
     static final String ERR_UNSUPPORTED_REPORT_ID_TEMPLATE = "Unsupported 'reportId': %s";
 
     private ErrorMessages() {}

--- a/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ObjectMapperTest.java
+++ b/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ObjectMapperTest.java
@@ -10,6 +10,7 @@ import static org.olf.erm.usage.counter51.TestUtil.readFileAsObjectNode;
 import static org.olf.erm.usage.counter51.ValidationBeanDeserializerModifier.VALIDATION_FAILED_MSG;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.io.IOException;
@@ -73,7 +74,7 @@ class ObjectMapperTest {
       assertThatThrownBy(
               () ->
                   objectMapper.readValue(getSampleReportPath(ReportType.TR_J1).toFile(), TR.class))
-          .hasMessageContaining(VALIDATION_FAILED_MSG);
+          .isInstanceOf(ValueInstantiationException.class);
     }
   }
 }

--- a/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ObjectMapperTest.java
+++ b/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ObjectMapperTest.java
@@ -3,12 +3,14 @@ package org.olf.erm.usage.counter51;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.olf.erm.usage.counter51.TestUtil.TR_WITH_EXCEPTION;
+import static org.olf.erm.usage.counter51.TestUtil.TR_WITH_INVALID_EXCEPTION;
 import static org.olf.erm.usage.counter51.TestUtil.getObjectMapper;
 import static org.olf.erm.usage.counter51.TestUtil.getResourcePath;
 import static org.olf.erm.usage.counter51.TestUtil.getSampleReportPath;
 import static org.olf.erm.usage.counter51.TestUtil.readFileAsObjectNode;
 import static org.olf.erm.usage.counter51.ValidationBeanDeserializerModifier.VALIDATION_FAILED_MSG;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -34,6 +36,15 @@ class ObjectMapperTest {
   @Test
   void testDeserializationForReportWithException() throws IOException, ClassNotFoundException {
     testDeserialization(getResourcePath(TR_WITH_EXCEPTION).toFile(), ReportType.TR);
+  }
+
+  @Test
+  void testDeserializationForReportWithInvalidException() {
+    assertThatThrownBy(
+            () ->
+                testDeserialization(
+                    getResourcePath(TR_WITH_INVALID_EXCEPTION).toFile(), ReportType.TR))
+        .isInstanceOf(JsonMappingException.class);
   }
 
   private void testDeserialization(File file, ReportType reportType)

--- a/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ReportValidatorTest.java
+++ b/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ReportValidatorTest.java
@@ -1,17 +1,12 @@
 package org.olf.erm.usage.counter51;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.olf.erm.usage.counter51.JsonProperties.RELEASE;
-import static org.olf.erm.usage.counter51.JsonProperties.REPORT_ATTRIBUTES;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_HEADER;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_ID;
 import static org.olf.erm.usage.counter51.ReportType.TR;
 import static org.olf.erm.usage.counter51.ReportType.TR_J1;
 import static org.olf.erm.usage.counter51.ReportValidator.ErrorMessages.ERR_NO_REPORT_ID;
-import static org.olf.erm.usage.counter51.ReportValidator.ErrorMessages.ERR_RELEASE_TEMPLATE;
 import static org.olf.erm.usage.counter51.ReportValidator.ErrorMessages.ERR_REPORT_ATTRIBUTES_TEMPLATE;
-import static org.olf.erm.usage.counter51.ReportValidator.ErrorMessages.ERR_REPORT_ID_TEMPLATE;
-import static org.olf.erm.usage.counter51.ReportValidator.ErrorMessages.ERR_UNSUPPORTED_REPORT_ID_TEMPLATE;
 import static org.olf.erm.usage.counter51.TestUtil.TR_WITH_INVALID_REPORT_HEADER;
 import static org.olf.erm.usage.counter51.TestUtil.TR_WITH_INVALID_REPORT_ITEMS;
 import static org.olf.erm.usage.counter51.TestUtil.getReportValidator;
@@ -46,33 +41,6 @@ class ReportValidatorTest {
     assertThat(method2Result.isValid()).isTrue();
 
     assertThat(reportClone).isEqualTo(report);
-  }
-
-  @Test
-  void testInvalidReleaseVersion() throws IOException {
-    ObjectNode report = readFileAsObjectNode(getSampleReportPath(TR).toFile());
-    report.withObject(REPORT_HEADER).put(RELEASE, "5.0");
-
-    assertThat(reportValidator.validateReport(report))
-        .satisfies(
-            res -> {
-              assertThat(res.isValid()).isFalse();
-              assertThat(res.getErrorMessage())
-                  .contains(ERR_RELEASE_TEMPLATE.formatted(ReportValidator.RELEASE));
-            });
-  }
-
-  @Test
-  void testInvalidReportID() throws IOException {
-    ObjectNode report = readFileAsObjectNode(getSampleReportPath(TR).toFile());
-    String invalidReportID = "TR_2";
-    report.withObject(REPORT_HEADER).put(REPORT_ID, invalidReportID);
-
-    assertThat(reportValidator.validateReport(report))
-        .satisfies(
-            isInvalidWithMessage(ERR_UNSUPPORTED_REPORT_ID_TEMPLATE.formatted(invalidReportID)));
-    assertThat(reportValidator.validateReport(report, TR))
-        .satisfies(isInvalidWithMessage(ERR_REPORT_ID_TEMPLATE.formatted(TR)));
   }
 
   @Test
@@ -113,7 +81,7 @@ class ReportValidatorTest {
     ObjectNode report = readFileAsObjectNode(getSampleReportPath(TR).toFile());
 
     assertThat(reportValidator.validateReport(report, TR_J1))
-        .satisfies(isInvalidWithMessage(REPORT_ATTRIBUTES));
+        .satisfies(isInvalidWithMessage("Unexpected value 'TR'"));
   }
 
   private ThrowingConsumer<ValidationResult> isInvalidWithMessage(String message) {

--- a/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/TestUtil.java
+++ b/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/TestUtil.java
@@ -22,6 +22,7 @@ class TestUtil {
       new ReportConverter(objectMapper, reportValidator);
   static final String SAMPLE_REPORTS_PATH_TEMPLATE = "sample-reports/%s_sample_r51.%s";
   static final String TR_WITH_EXCEPTION = "TR_r51_with_exception.json";
+  static final String TR_WITH_INVALID_EXCEPTION = "TR_r51_with_invalid_exception.json";
   static final String TR_WITH_INVALID_REPORT_HEADER = "TR_r51_with_invalid_report_header.json";
   static final String TR_WITH_INVALID_REPORT_ITEMS = "TR_r51_with_invalid_report_items.json";
   static final String DEFAULT_EXTENSION = "json";

--- a/mod-erm-usage-counter51/src/test/resources/TR_r51_with_invalid_exception.json
+++ b/mod-erm-usage-counter51/src/test/resources/TR_r51_with_invalid_exception.json
@@ -25,8 +25,8 @@
     },
     "Exceptions": [
       {
-        "Code": 3031,
-        "Message": "Usage Not Ready for Requested Dates",
+        "Code": 2000,
+        "Message": "Requestor Not Authorized to Access Service",
         "Help_URL": "http://example.com",
         "Data": "string"
       }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUSCNT-58

* Updates `openapi-generator` to `v7.12.0`
* Removes customizations in java code generation
* Fixes test sample report