### PR TITLE
Run Spotless on all files and bind check goal to compile phase

### DIFF
--- a/mod-erm-usage-counter41/src/main/java/org/olf/erm/usage/counter41/Counter4Utils.java
+++ b/mod-erm-usage-counter41/src/main/java/org/olf/erm/usage/counter41/Counter4Utils.java
@@ -229,7 +229,8 @@ public class Counter4Utils {
 
     if (!Stream.of(clonedReports).allMatch(r -> r.getCustomer().size() == 1)) {
       throw new ReportMergeException(
-          "At least one report contains invalid customer definitions (expecting one customer per report)");
+          "At least one report contains invalid customer definitions (expecting one customer per"
+              + " report)");
     }
 
     // check that provided reports have the same attributes

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,6 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <version>${spotless.version}</version>
         <configuration>
-          <ratchetFrom>origin/master</ratchetFrom>
           <java>
             <googleJavaFormat>
               <version>${google-java-format.version}</version>
@@ -170,6 +169,16 @@
             </googleJavaFormat>
           </java>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>
+              compile
+            </phase>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Remove `ratchetFrom` so Spotless applies to the entire codebase and add an execution to run `spotless:check` during the `compile` phase.