### PR TITLE
Bind Spotless check goal to verify phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
               <goal>check</goal>
             </goals>
             <phase>
-              compile
+              verify
             </phase>
           </execution>
         </executions>


### PR DESCRIPTION
The compile phase is overly restrictive as it enforces formatting requirements during routine development tasks such as compilation and testing. Moving the check to the verify phase allows developers to iterate freely while still ensuring formatting compliance in CI.