### PR TITLE
[MODEUSCNT-69] Use order-insensitive comparison for R5.1 report attribute arrays

### DIFF
--- a/mod-erm-usage-counter51/src/main/java/org/olf/erm/usage/counter51/ReportValidator.java
+++ b/mod-erm-usage-counter51/src/main/java/org/olf/erm/usage/counter51/ReportValidator.java
@@ -11,6 +11,8 @@ import static org.olf.erm.usage.counter51.ReportValidator.ErrorMessages.ERR_UNSU
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Comparator;
+import java.util.stream.StreamSupport;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class ReportValidator {
@@ -72,12 +74,33 @@ class ReportValidator {
     ObjectNode expectedReportAttributes =
         objectMapper.convertValue(
             reportType.getProperties().getReportAttributes(), ObjectNode.class);
-    if (reportAttributes.equals(expectedReportAttributes)) {
+    if (normalize(reportAttributes).equals(normalize(expectedReportAttributes))) {
       return ValidationResult.success();
     } else {
       return ValidationResult.error(
           ERR_REPORT_ATTRIBUTES_TEMPLATE, expectedReportAttributes.toString());
     }
+  }
+
+  /**
+   * Normalizes report attributes by sorting array values, so that element order does not affect
+   * equality comparisons.
+   */
+  private static ObjectNode normalize(JsonNode node) {
+    ObjectNode result = node.deepCopy();
+    node.fields()
+        .forEachRemaining(
+            entry -> {
+              if (entry.getValue().isArray()) {
+                result
+                    .putArray(entry.getKey())
+                    .addAll(
+                        StreamSupport.stream(entry.getValue().spliterator(), false)
+                            .sorted(Comparator.comparing(JsonNode::toString))
+                            .toList());
+              }
+            });
+    return result;
   }
 
   private Class<?> getReportClass(ReportType reportType) throws ClassNotFoundException {

--- a/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ReportValidatorTest.java
+++ b/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ReportValidatorTest.java
@@ -1,6 +1,8 @@
 package org.olf.erm.usage.counter51;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.olf.erm.usage.counter51.JsonProperties.ATTRIBUTES_TO_SHOW;
+import static org.olf.erm.usage.counter51.JsonProperties.REPORT_ATTRIBUTES;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_HEADER;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_ID;
 import static org.olf.erm.usage.counter51.ReportType.TR;
@@ -14,9 +16,13 @@ import static org.olf.erm.usage.counter51.TestUtil.getResourcePath;
 import static org.olf.erm.usage.counter51.TestUtil.getSampleReportPath;
 import static org.olf.erm.usage.counter51.TestUtil.readFileAsObjectNode;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.StreamSupport;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -82,6 +88,25 @@ class ReportValidatorTest {
 
     assertThat(reportValidator.validateReport(report, TR_J1))
         .satisfies(isInvalidWithMessage("Unexpected value 'TR'"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ReportType.class,
+      names = {"TR", "DR", "IR", "PR"})
+  void testValidReportsWithReversedAttributesToShow(ReportType reportType) throws IOException {
+    ObjectNode report = readFileAsObjectNode(getSampleReportPath(reportType).toFile());
+    ArrayNode attributesToShow =
+        (ArrayNode) report.path(REPORT_HEADER).path(REPORT_ATTRIBUTES).path(ATTRIBUTES_TO_SHOW);
+
+    List<JsonNode> reversedElements =
+        StreamSupport.stream(attributesToShow.spliterator(), false).toList().reversed();
+    attributesToShow.removeAll().addAll(reversedElements);
+
+    assertThat(reportValidator.validateReport(report))
+        .satisfies(res -> assertThat(res.isValid()).isTrue());
+    assertThat(reportValidator.validateReport(report, reportType))
+        .satisfies(res -> assertThat(res.isValid()).isTrue());
   }
 
   private ThrowingConsumer<ValidationResult> isInvalidWithMessage(String message) {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUSCNT-69

## Purpose

The `ReportValidator.validateReportHeaderReportAttributes()` method uses an order-sensitive comparison (`equals`) when checking report attributes against expected values. This causes valid reports to be rejected when a provider returns the `Attributes_To_Show` array elements in a different order than what is defined in `ReportProperties`. For example, a TR report expecting `["YOP", "Access_Type", "Access_Method"]` would fail validation if a provider returns `["Access_Method", "YOP", "Access_Type"]`, even though the content is identical.

## Approach

- Replaced the direct `equals` comparison with a new `reportAttributesMatch` method that compares object fields individually, using set-based comparison for array values via `arrayEqualsIgnoreOrder`
- Added a parameterized test covering TR, DR, IR, and PR report types that reverses the `Attributes_To_Show` array order and verifies validation still passes
