### PR TITLE
[MODEUSCNT-70] Use order-insensitive comparison in report merging logic

### DIFF
--- a/mod-erm-usage-counter50/src/main/java/org/olf/erm/usage/counter50/merger/ReportsMerger.java
+++ b/mod-erm-usage-counter50/src/main/java/org/olf/erm/usage/counter50/merger/ReportsMerger.java
@@ -1,10 +1,15 @@
 package org.olf.erm.usage.counter50.merger;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import org.olf.erm.usage.counter50.Counter5Utils;
 import org.openapitools.counter50.model.SUSHIErrorModel;
@@ -46,7 +51,7 @@ public abstract class ReportsMerger<T> {
             .map(SUSHIReportHeader::getReportAttributes)
             .filter(Objects::nonNull)
             .flatMap(Collection::stream)
-            .distinct()
+            .filter(distinctByNormalized(ReportsMerger::normalizeReportAttribute))
             .collect(Collectors.toList());
     result.setReportAttributes(reportAttributes.isEmpty() ? null : reportAttributes);
 
@@ -71,7 +76,7 @@ public abstract class ReportsMerger<T> {
                 f ->
                     !(f.getName().equalsIgnoreCase("begin_date")
                         || f.getName().equalsIgnoreCase("end_date")))
-            .distinct()
+            .filter(distinctByNormalized(ReportsMerger::normalizeReportFilter))
             .collect(Collectors.toList());
 
     List<LocalDate> allDates =
@@ -92,5 +97,35 @@ public abstract class ReportsMerger<T> {
     filtersWithoutDates.add(beginFilter);
     filtersWithoutDates.add(endFilter);
     return filtersWithoutDates;
+  }
+
+  private static <T> Predicate<T> distinctByNormalized(UnaryOperator<T> normalizer) {
+    Set<T> seen = new LinkedHashSet<>();
+    return t -> seen.add(normalizer.apply(t));
+  }
+
+  private static String normalizePipeDelimitedValue(String value) {
+    if (value == null || !value.contains("|")) {
+      return value;
+    }
+    String[] segments = value.split("\\|");
+    Arrays.sort(segments);
+    return String.join("|", segments);
+  }
+
+  private static SUSHIReportHeaderReportAttributes normalizeReportAttribute(
+      SUSHIReportHeaderReportAttributes attr) {
+    SUSHIReportHeaderReportAttributes normalized = new SUSHIReportHeaderReportAttributes();
+    normalized.setName(attr.getName());
+    normalized.setValue(normalizePipeDelimitedValue(attr.getValue()));
+    return normalized;
+  }
+
+  private static SUSHIReportHeaderReportFilters normalizeReportFilter(
+      SUSHIReportHeaderReportFilters filter) {
+    SUSHIReportHeaderReportFilters normalized = new SUSHIReportHeaderReportFilters();
+    normalized.setName(filter.getName());
+    normalized.setValue(normalizePipeDelimitedValue(filter.getValue()));
+    return normalized;
   }
 }

--- a/mod-erm-usage-counter50/src/test/java/org/olf/erm/usage/counter50/merger/ReportsMergerTest.java
+++ b/mod-erm-usage-counter50/src/test/java/org/olf/erm/usage/counter50/merger/ReportsMergerTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import org.junit.Test;
 import org.openapitools.counter50.model.COUNTERTitleReport;
 import org.openapitools.counter50.model.SUSHIReportHeader;
+import org.openapitools.counter50.model.SUSHIReportHeaderReportAttributes;
+import org.openapitools.counter50.model.SUSHIReportHeaderReportFilters;
 
 public class ReportsMergerTest {
 
@@ -26,6 +28,46 @@ public class ReportsMergerTest {
     assertThat(new TestMerger().mergeHeaders(asList(header1, header2)))
         .isEqualTo(header1)
         .isEqualTo(header2);
+  }
+
+  @Test
+  public void testMergeHeadersNormalizesPipeDelimitedValues() {
+    SUSHIReportHeaderReportAttributes attrToShow1 = new SUSHIReportHeaderReportAttributes();
+    attrToShow1.setName("Attributes_To_Show");
+    attrToShow1.setValue("Data_Type|Section_Type|YOP|Access_Type|Access_Method");
+
+    SUSHIReportHeaderReportAttributes attrToShow2 = new SUSHIReportHeaderReportAttributes();
+    attrToShow2.setName("Attributes_To_Show");
+    attrToShow2.setValue("Access_Method|Access_Type|Data_Type|Section_Type|YOP");
+
+    SUSHIReportHeaderReportAttributes excludeMonthly = new SUSHIReportHeaderReportAttributes();
+    excludeMonthly.setName("Exclude_Monthly_Details");
+    excludeMonthly.setValue("True");
+
+    SUSHIReportHeaderReportFilters filter1 = new SUSHIReportHeaderReportFilters();
+    filter1.setName("Metric_Type");
+    filter1.setValue("Total_Item_Requests|Unique_Item_Requests");
+
+    SUSHIReportHeaderReportFilters filter2 = new SUSHIReportHeaderReportFilters();
+    filter2.setName("Metric_Type");
+    filter2.setValue("Unique_Item_Requests|Total_Item_Requests");
+
+    SUSHIReportHeader header1 = new SUSHIReportHeader();
+    header1.setReportAttributes(List.of(attrToShow1, excludeMonthly));
+    header1.setReportFilters(List.of(filter1));
+
+    SUSHIReportHeader header2 = new SUSHIReportHeader();
+    header2.setReportAttributes(List.of(attrToShow2, excludeMonthly));
+    header2.setReportFilters(List.of(filter2));
+
+    SUSHIReportHeader merged = new TestMerger().mergeHeaders(asList(header1, header2));
+    assertThat(merged.getReportAttributes()).hasSize(2);
+    assertThat(merged.getReportAttributes().get(0).getValue())
+        .isEqualTo("Data_Type|Section_Type|YOP|Access_Type|Access_Method");
+    assertThat(merged.getReportAttributes().get(1).getValue()).isEqualTo("True");
+    assertThat(merged.getReportFilters()).hasSize(1);
+    assertThat(merged.getReportFilters().get(0).getValue())
+        .isEqualTo("Total_Item_Requests|Unique_Item_Requests");
   }
 
   @Test

--- a/mod-erm-usage-counter51/src/main/java/org/olf/erm/usage/counter51/ReportMerger.java
+++ b/mod-erm-usage-counter51/src/main/java/org/olf/erm/usage/counter51/ReportMerger.java
@@ -58,7 +58,12 @@ class ReportMerger {
         reports.stream().map(on -> on.withObject(REPORT_HEADER)).map(ObjectNode::deepCopy).toList();
 
     boolean reportsHaveUniformHeaderProperties =
-        reportHeaders.stream().map(this::removeHeaderProperties).distinct().count() == 1;
+        reportHeaders.stream()
+                .map(this::removeHeaderProperties)
+                .map(ReportValidator::normalize)
+                .distinct()
+                .count()
+            == 1;
     if (!reportsHaveUniformHeaderProperties) {
       throw new IllegalArgumentException(MSG_PROPERTIES_DO_NOT_MATCH);
     }

--- a/mod-erm-usage-counter51/src/main/java/org/olf/erm/usage/counter51/ReportValidator.java
+++ b/mod-erm-usage-counter51/src/main/java/org/olf/erm/usage/counter51/ReportValidator.java
@@ -83,10 +83,10 @@ class ReportValidator {
   }
 
   /**
-   * Normalizes report attributes by sorting array values, so that element order does not affect
-   * equality comparisons.
+   * Normalizes a JSON object by sorting array values, so that element order does not affect
+   * equality comparisons. Recurses into nested objects.
    */
-  private static ObjectNode normalize(JsonNode node) {
+  static ObjectNode normalize(JsonNode node) {
     ObjectNode result = node.deepCopy();
     node.fields()
         .forEachRemaining(
@@ -98,6 +98,8 @@ class ReportValidator {
                         StreamSupport.stream(entry.getValue().spliterator(), false)
                             .sorted(Comparator.comparing(JsonNode::toString))
                             .toList());
+              } else if (entry.getValue().isObject()) {
+                result.set(entry.getKey(), normalize(entry.getValue()));
               }
             });
     return result;

--- a/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/Counter51UtilsTest.java
+++ b/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/Counter51UtilsTest.java
@@ -7,10 +7,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.olf.erm.usage.counter51.Counter51Utils.mergeReports;
 import static org.olf.erm.usage.counter51.Counter51Utils.splitReport;
 import static org.olf.erm.usage.counter51.Counter51Utils.writeReportAsCsv;
+import static org.olf.erm.usage.counter51.JsonProperties.ATTRIBUTES_TO_SHOW;
 import static org.olf.erm.usage.counter51.JsonProperties.BEGIN_DATE;
 import static org.olf.erm.usage.counter51.JsonProperties.CREATED;
 import static org.olf.erm.usage.counter51.JsonProperties.END_DATE;
 import static org.olf.erm.usage.counter51.JsonProperties.PERFORMANCE;
+import static org.olf.erm.usage.counter51.JsonProperties.REPORT_ATTRIBUTES;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_FILTERS;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_HEADER;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_ID;
@@ -28,12 +30,14 @@ import static org.olf.erm.usage.counter51.TestUtil.removeBOMAndTrailingDelimiter
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -88,6 +92,33 @@ class Counter51UtilsTest {
 
     assertThatThrownBy(() -> mergeReports(Arrays.asList(report1, report2)))
         .hasMessage(MSG_ERROR_MERGING_REPORT + MSG_PROPERTIES_DO_NOT_MATCH);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ReportType.class,
+      names = {"TR", "DR", "IR", "PR"})
+  void testMergeReportsWithReorderedReportAttributes(ReportType reportType) throws IOException {
+    ObjectNode report = readFileAsObjectNode(getSampleReportPath(reportType).toFile());
+    List<ObjectNode> splitReports = splitReport(report);
+
+    ArrayNode attributesToShow =
+        (ArrayNode)
+            splitReports
+                .get(0)
+                .path(REPORT_HEADER)
+                .path(REPORT_ATTRIBUTES)
+                .path(ATTRIBUTES_TO_SHOW);
+
+    List<JsonNode> reversedElements =
+        StreamSupport.stream(attributesToShow.spliterator(), false).toList().reversed();
+    attributesToShow.removeAll().addAll(reversedElements);
+
+    ObjectNode mergedReport = mergeReports(splitReports);
+    assertThatJson(mergedReport)
+        .when(IGNORING_ARRAY_ORDER)
+        .whenIgnoringPaths(REPORT_HEADER + "." + CREATED)
+        .isEqualTo(report);
   }
 
   @Test


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUSCNT-70

## Purpose

The report merging logic in both COUNTER 5.0 and 5.1 modules performs order-sensitive comparisons on report header attributes. This causes merge failures when attribute arrays or pipe-delimited values appear in different orders across reports that are otherwise equivalent. The validation code paths were already fixed in #103 and [mod-erm-usage#212](https://github.com/folio-org/mod-erm-usage/pull/212), but the merging code paths were not covered.

## Approach

- COUNTER 5.1 `ReportMerger`: Apply `ReportValidator.normalize()` to report headers before the distinctness check during merge validation. Made `normalize()` package-private and added recursion into nested objects so it handles the full header structure.
- COUNTER 5.0 `ReportsMerger`: Replace `distinct()` with a `distinctByNormalized()` predicate that normalizes pipe-delimited values (split, sort, rejoin) before deduplication, applied to both report attributes and report filters.
- Added tests in both modules covering merge scenarios with reordered attributes.