### PR TITLE
[MODEUSCNT-72] Bump Apache CXF from 4.1.4 to 4.1.7

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 6.1.0 (IN PROGRESS)
+* [MODEUSCNT-72](https://folio-org.atlassian.net/browse/MODEUSCNT-72) Bump Apache CXF from 4.1.4 to 4.1.7 fixing vulnerabilities
+
 ## 6.0.0
 * [MODEUSCNT-61](https://folio-org.atlassian.net/browse/MODEUSCNT-61) Create utility to convert COUNTER 5.1 Master Reports (TSV/CSV/XLSX) to JSON
 * [MODEUSCNT-62](https://folio-org.atlassian.net/browse/MODEUSCNT-62) Upgrade commons-beanutils from 1.10.1 to 1.11.0 fixing CVE-2025-48734

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <super-csv.version>2.4.0</super-csv.version>
     <super-csv.beanutils.version>1.11.0</super-csv.beanutils.version>
     <commons-csv.version>1.13.0</commons-csv.version>
-    <cxf.version>4.1.4</cxf.version>
+    <cxf.version>4.1.7</cxf.version>
     <vertx.version>5.0.10</vertx.version>
     <jackson.version>2.21.2</jackson.version>
     <spotless.version>2.44.4</spotless.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUSCNT-72

## Purpose

Apache CXF 4.1.4 and its transitive dependency Apache Neethi are affected by documented security vulnerabilities. Upgrading Apache CXF to 4.1.7 resolves the reported advisories in both packages.

## Approach

Bump the `cxf.version` property in `pom.xml` from `4.1.4` to `4.1.7` and record the change in `NEWS.md`.