### PR TITLE
[MODEUSCNT-74] Allow both registry domains for Registry_Record in COUNTER 5.1 reports

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 6.1.0 (IN PROGRESS)
 * [MODEUSCNT-72](https://folio-org.atlassian.net/browse/MODEUSCNT-72) Bump Apache CXF from 4.1.4 to 4.1.7 fixing vulnerabilities
 * [MODEUSCNT-73](https://folio-org.atlassian.net/browse/MODEUSCNT-73) Bump Vert.x from 5.0.10 to 5.1.5 fixing Netty vulnerabilities
+* [MODEUSCNT-74](https://folio-org.atlassian.net/browse/MODEUSCNT-74) Allow both registry.countermetrics.org and registry.projectcounter.org domains for Registry_Record in COUNTER 5.1 reports
 
 ## 6.0.0
 * [MODEUSCNT-61](https://folio-org.atlassian.net/browse/MODEUSCNT-61) Create utility to convert COUNTER 5.1 Master Reports (TSV/CSV/XLSX) to JSON

--- a/mod-erm-usage-counter51/src/main/resources/COUNTER_API.json
+++ b/mod-erm-usage-counter51/src/main/resources/COUNTER_API.json
@@ -6,7 +6,7 @@
     "info": {
         "title": "COUNTER API",
         "version": "5.1.0.1-modified",
-        "description": "This version of the COUNTER API (formerly sushi) applies to Release 5.1.0.1 of the COUNTER Code of Practice, which can be read online at https://cop5.countermetrics.org/.\n\nThis workspace provides a detailed description of the entire COUNTER API, including the JSON schema for COUNTER Reports and Standard Views of the COUNTER Reports. \n\nIt is expected that reporting services will use only the parts relevant to them, or make local tailored copies relevant to their particular circumstances, for example by removing methods detailing reports they do not support.\n\nIf you have any queries, please contact the Executive Director (code@countermetrics.org).\n\nThis copy deviates from the official 5.1.0.1 release: the Registry_Record pattern additionally permits the registry.projectcounter.org domain, backporting the planned change from Project-Counter/cop5#392 (MODEUSCNT-74).",
+        "description": "This version of the COUNTER API (formerly sushi) applies to Release 5.1.0.1 of the COUNTER Code of Practice, which can be read online at https://cop5.countermetrics.org/.\n\nThis workspace provides a detailed description of the entire COUNTER API, including the JSON schema for COUNTER Reports and Standard Views of the COUNTER Reports. \n\nIt is expected that reporting services will use only the parts relevant to them, or make local tailored copies relevant to their particular circumstances, for example by removing methods detailing reports they do not support.\n\nIf you have any queries, please contact the Executive Director (code@countermetrics.org).\n\nThis copy deviates from the official 5.1.0.1 release: the Registry_Record pattern additionally permits the registry.projectcounter.org domain and matches the dots in the hostname literally, backporting the planned change from Project-Counter/cop5#392 (MODEUSCNT-74).",
         "summary": "COUNTER API for Release 5.1.0.1",
         "license": {
             "name": "CC BY 4.0",
@@ -1281,7 +1281,7 @@
                     },
                     "Registry_Record": {
                         "type": "string",
-                        "pattern": "^(https://registry.(countermetrics|projectcounter).org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
+                        "pattern": "^(https://registry\\.(countermetrics|projectcounter)\\.org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
                         "description": "The link to the platform’s COUNTER Registry record. Report providers who do not have a Registry record MUST omit this element."
                     },
                     "Note": {
@@ -7426,7 +7426,7 @@
                     },
                     "Registry_Record": {
                         "type": "string",
-                        "pattern": "^(https://registry.(countermetrics|projectcounter).org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
+                        "pattern": "^(https://registry\\.(countermetrics|projectcounter)\\.org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
                         "description": "The link to the platform’s COUNTER Registry record. Report providers who do not have a Registry record MUST leave the value blank."
                     }
                 },

--- a/mod-erm-usage-counter51/src/main/resources/COUNTER_API.json
+++ b/mod-erm-usage-counter51/src/main/resources/COUNTER_API.json
@@ -5,8 +5,8 @@
     },
     "info": {
         "title": "COUNTER API",
-        "version": "5.1.0.1",
-        "description": "This version of the COUNTER API (formerly sushi) applies to Release 5.1.0.1 of the COUNTER Code of Practice, which can be read online at https://cop5.countermetrics.org/.\n\nThis workspace provides a detailed description of the entire COUNTER API, including the JSON schema for COUNTER Reports and Standard Views of the COUNTER Reports. \n\nIt is expected that reporting services will use only the parts relevant to them, or make local tailored copies relevant to their particular circumstances, for example by removing methods detailing reports they do not support.\n\nIf you have any queries, please contact the Executive Director (code@countermetrics.org).",
+        "version": "5.1.0.1-modified",
+        "description": "This version of the COUNTER API (formerly sushi) applies to Release 5.1.0.1 of the COUNTER Code of Practice, which can be read online at https://cop5.countermetrics.org/.\n\nThis workspace provides a detailed description of the entire COUNTER API, including the JSON schema for COUNTER Reports and Standard Views of the COUNTER Reports. \n\nIt is expected that reporting services will use only the parts relevant to them, or make local tailored copies relevant to their particular circumstances, for example by removing methods detailing reports they do not support.\n\nIf you have any queries, please contact the Executive Director (code@countermetrics.org).\n\nThis copy deviates from the official 5.1.0.1 release: the Registry_Record pattern additionally permits the registry.projectcounter.org domain, backporting the planned change from Project-Counter/cop5#392 (MODEUSCNT-74).",
         "summary": "COUNTER API for Release 5.1.0.1",
         "license": {
             "name": "CC BY 4.0",
@@ -1281,7 +1281,7 @@
                     },
                     "Registry_Record": {
                         "type": "string",
-                        "pattern": "^(https://registry.countermetrics.org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
+                        "pattern": "^(https://registry.(countermetrics|projectcounter).org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
                         "description": "The link to the platform’s COUNTER Registry record. Report providers who do not have a Registry record MUST omit this element."
                     },
                     "Note": {
@@ -7426,7 +7426,7 @@
                     },
                     "Registry_Record": {
                         "type": "string",
-                        "pattern": "^(https://registry.countermetrics.org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
+                        "pattern": "^(https://registry.(countermetrics|projectcounter).org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
                         "description": "The link to the platform’s COUNTER Registry record. Report providers who do not have a Registry record MUST leave the value blank."
                     }
                 },

--- a/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ReportValidatorTest.java
+++ b/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ReportValidatorTest.java
@@ -130,14 +130,15 @@ class ReportValidatorTest {
         .satisfies(res -> assertThat(res.isValid()).isTrue());
   }
 
-  @Test
-  void testInvalidRegistryRecord() throws IOException {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "https://registry.example.org/platform/99999999-9999-9999-9999-999999999999",
+        "https://registry-countermetrics-org/platform/99999999-9999-9999-9999-999999999999"
+      })
+  void testInvalidRegistryRecord(String registryRecord) throws IOException {
     ObjectNode report = readFileAsObjectNode(getSampleReportPath(TR).toFile());
-    report
-        .withObject(REPORT_HEADER)
-        .put(
-            REGISTRY_RECORD,
-            "https://registry.example.org/platform/99999999-9999-9999-9999-999999999999");
+    report.withObject(REPORT_HEADER).put(REGISTRY_RECORD, registryRecord);
 
     assertThat(reportValidator.validateReport(report))
         .satisfies(isInvalidWithMessage("registryRecord"));

--- a/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ReportValidatorTest.java
+++ b/mod-erm-usage-counter51/src/test/java/org/olf/erm/usage/counter51/ReportValidatorTest.java
@@ -2,6 +2,7 @@ package org.olf.erm.usage.counter51;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.olf.erm.usage.counter51.JsonProperties.ATTRIBUTES_TO_SHOW;
+import static org.olf.erm.usage.counter51.JsonProperties.REGISTRY_RECORD;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_ATTRIBUTES;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_HEADER;
 import static org.olf.erm.usage.counter51.JsonProperties.REPORT_ID;
@@ -27,6 +28,7 @@ import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.olf.erm.usage.counter51.ReportValidator.ValidationResult;
 
 class ReportValidatorTest {
@@ -107,6 +109,40 @@ class ReportValidatorTest {
         .satisfies(res -> assertThat(res.isValid()).isTrue());
     assertThat(reportValidator.validateReport(report, reportType))
         .satisfies(res -> assertThat(res.isValid()).isTrue());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "https://registry.countermetrics.org/platform/99999999-9999-9999-9999-999999999999",
+        "https://registry.projectcounter.org/platform/99999999-9999-9999-9999-999999999999",
+        "https://registry.countermetrics.org/usage-data-host/99999999-9999-9999-9999-999999999999",
+        "https://registry.projectcounter.org/usage-data-host/99999999-9999-9999-9999-999999999999",
+        ""
+      })
+  void testValidRegistryRecord(String registryRecord) throws IOException {
+    ObjectNode report = readFileAsObjectNode(getSampleReportPath(TR).toFile());
+    report.withObject(REPORT_HEADER).put(REGISTRY_RECORD, registryRecord);
+
+    assertThat(reportValidator.validateReport(report))
+        .satisfies(res -> assertThat(res.isValid()).isTrue());
+    assertThat(reportValidator.validateReport(report, TR))
+        .satisfies(res -> assertThat(res.isValid()).isTrue());
+  }
+
+  @Test
+  void testInvalidRegistryRecord() throws IOException {
+    ObjectNode report = readFileAsObjectNode(getSampleReportPath(TR).toFile());
+    report
+        .withObject(REPORT_HEADER)
+        .put(
+            REGISTRY_RECORD,
+            "https://registry.example.org/platform/99999999-9999-9999-9999-999999999999");
+
+    assertThat(reportValidator.validateReport(report))
+        .satisfies(isInvalidWithMessage("registryRecord"));
+    assertThat(reportValidator.validateReport(report, TR))
+        .satisfies(isInvalidWithMessage("registryRecord"));
   }
 
   private ThrowingConsumer<ValidationResult> isInvalidWithMessage(String message) {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUSCNT-74

## Purpose

The bundled COUNTER 5.1 API schema (`COUNTER_API.json`, Release 5.1.0.1) only accepts `Registry_Record` URLs from the `registry.countermetrics.org` domain. The original COUNTER 5.1 specification used `registry.projectcounter.org`, and the domain transition in 5.1.1 did not keep the old domain valid in the schema pattern. Reports from providers still using the older domain (e.g. Cambridge Core, ProQuest, MIT Press Direct, and over 15 others) fail validation, which prevents COUNTER 5.1 harvesting from succeeding. The upstream fix accepting both domains (Project-Counter/cop5#392) is not yet part of an official release, so it is backported here.

## Approach

- Change the `Registry_Record` pattern in both schema definitions in `COUNTER_API.json` to accept `registry.(countermetrics|projectcounter).org`, matching the upstream change
- Mark the bundled schema as `5.1.0.1-modified` and document the deviation in its description
- Add tests validating that both registry domains (and an empty value) pass validation while other domains are rejected